### PR TITLE
Fix behavior when the index isn't there.

### DIFF
--- a/server/search.go
+++ b/server/search.go
@@ -260,6 +260,7 @@ func (s *Server) Search(ctx context.Context, in *pb.SearchRequest) (*pb.Outputs,
 		res, err := client.IndexStats(searchIndices[0]).Do(ctx)
 		if err != nil {
 			log.Printf("Error on ES index stats\n%v\n", err)
+			return &pb.Outputs{}, nil
 		}
 		numRefreshes := res.Indices[searchIndices[0]].Primaries.Refresh.Total
 		if numRefreshes != s.NumESRefreshes {


### PR DESCRIPTION
One of the tests expects an empty list returned, we're currently
returning an error.