### PR TITLE
Fix release_time query to match python hub. 

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -446,20 +446,24 @@ func GetProdDB(name string, secondaryPath string) (*ReadOnlyDBColumnFamily, func
 
 	db, err := GetDBColumnFamilies(name, secondaryPath, cfNames)
 
-	cleanup := func() {
-		db.DB.Close()
+	cleanupFiles := func() {
 		err = os.RemoveAll(secondaryPath)
 		if err != nil {
 			log.Println(err)
 		}
 	}
-	db.Cleanup = cleanup
 
 	if err != nil {
-		return nil, cleanup, err
+		return nil, cleanupFiles, err
 	}
 
-	return db, cleanup, nil
+	cleanupDB := func() {
+		db.DB.Close()
+		cleanupFiles()
+	}
+	db.Cleanup = cleanupDB
+
+	return db, cleanupDB, nil
 }
 
 // GetDBColumnFamilies gets a db with the specified column families and secondary path.


### PR DESCRIPTION
Fixes https://github.com/lbryio/herald/issues/40

Primary purpose is to adjust the query to match Python claim search:
https://github.com/lbryio/hub/blob/eb87474b480f77cd2849156136101f642202fed3/hub/common.py#L603

Also contains some changes to GetProdDB to avoid panic when DB is not found. Can be unbundled if desired.

Still struggling to run tests locally (MacOS) to prove the fix is sufficient to make test_setting_stream_fields pass.