### PR TITLE
Add element type param T to SlicedBacked[T]. Require T satisfy

### DIFF
--- a/db/db_resolve.go
+++ b/db/db_resolve.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/lbryio/herald.go/db/prefixes"
+	"github.com/lbryio/herald.go/db/stack"
 	"github.com/lbryio/herald.go/internal"
 	pb "github.com/lbryio/herald.go/protobuf/go"
 	lbryurl "github.com/lbryio/lbry.go/v3/url"
@@ -40,7 +41,8 @@ func PrepareResolveResult(
 		return nil, err
 	}
 
-	height, createdHeight := db.TxCounts.TxCountsBisectRight(txNum, rootTxNum)
+	heights := stack.BisectRight(db.TxCounts, []uint32{txNum, rootTxNum})
+	height, createdHeight := heights[0], heights[1]
 	lastTakeoverHeight := controllingClaim.Height
 
 	expirationHeight := GetExpirationHeight(height)
@@ -86,7 +88,7 @@ func PrepareResolveResult(
 				return nil, err
 			}
 			repostTxPostition = repostTxo.Position
-			repostHeight, _ = db.TxCounts.TxCountsBisectRight(repostTxo.TxNum, rootTxNum)
+			repostHeight = stack.BisectRight(db.TxCounts, []uint32{repostTxo.TxNum})[0]
 		}
 	}
 
@@ -122,7 +124,7 @@ func PrepareResolveResult(
 				return nil, err
 			}
 			channelTxPostition = channelVals.Position
-			channelHeight, _ = db.TxCounts.TxCountsBisectRight(channelVals.TxNum, rootTxNum)
+			channelHeight = stack.BisectRight(db.TxCounts, []uint32{channelVals.TxNum})[0]
 		}
 	}
 

--- a/db/stack/stack_test.go
+++ b/db/stack/stack_test.go
@@ -10,7 +10,7 @@ import (
 func TestPush(t *testing.T) {
 	var want uint32 = 3
 
-	stack := stack.NewSliceBacked(10)
+	stack := stack.NewSliceBacked[int](10)
 
 	stack.Push(0)
 	stack.Push(1)
@@ -22,7 +22,7 @@ func TestPush(t *testing.T) {
 }
 
 func TestPushPop(t *testing.T) {
-	stack := stack.NewSliceBacked(10)
+	stack := stack.NewSliceBacked[int](10)
 
 	for i := 0; i < 5; i++ {
 		stack.Push(i)
@@ -46,20 +46,20 @@ func TestPushPop(t *testing.T) {
 	}
 }
 
-func doPushes(stack *stack.SliceBacked, numPushes int) {
+func doPushes(stack *stack.SliceBacked[int], numPushes int) {
 	for i := 0; i < numPushes; i++ {
 		stack.Push(i)
 	}
 }
 
-func doPops(stack *stack.SliceBacked, numPops int) {
+func doPops(stack *stack.SliceBacked[int], numPops int) {
 	for i := 0; i < numPops; i++ {
 		stack.Pop()
 	}
 }
 
 func TestMultiThreaded(t *testing.T) {
-	stack := stack.NewSliceBacked(100000)
+	stack := stack.NewSliceBacked[int](100000)
 
 	go doPushes(stack, 100000)
 	go doPushes(stack, 100000)
@@ -83,7 +83,7 @@ func TestMultiThreaded(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	stack := stack.NewSliceBacked(10)
+	stack := stack.NewSliceBacked[int](10)
 
 	for i := 0; i < 5; i++ {
 		stack.Push(i)
@@ -99,6 +99,10 @@ func TestGet(t *testing.T) {
 		}
 	}
 
+	if got := stack.Get(5); got != 0 {
+		t.Errorf("got %v, want %v", got, 0)
+	}
+
 	slice := stack.GetSlice()
 
 	if len(slice) != 10 {
@@ -107,7 +111,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestLenCap(t *testing.T) {
-	stack := stack.NewSliceBacked(10)
+	stack := stack.NewSliceBacked[int](10)
 
 	if got := stack.Len(); got != 0 {
 		t.Errorf("got %v, want %v", got, 0)

--- a/internal/search.go
+++ b/internal/search.go
@@ -1,10 +1,14 @@
 package internal
 
-import "sort"
+import (
+	"sort"
+
+	"golang.org/x/exp/constraints"
+)
 
 // BisectRight returns the index of the first element in the list that is greater than or equal to the value.
 // https://stackoverflow.com/questions/29959506/is-there-a-go-analog-of-pythons-bisect-module
-func BisectRight(arr []interface{}, val uint32) uint32 {
-	i := sort.Search(len(arr), func(i int) bool { return arr[i].(uint32) >= val })
+func BisectRight[T constraints.Ordered](arr []T, val T) uint32 {
+	i := sort.Search(len(arr), func(i int) bool { return arr[i] >= val })
 	return uint32(i)
 }


### PR DESCRIPTION
Add element type param T to SlicedBacked[T]. Require T satisfy constraints.Ordered to make BisectRight() statically type-safe.

Found this working on the RPCs. I want to use `db.TxCounts` to lookup the height of a TXO. (And I don't have **two** txcounts, just one). While changing the argument/return signature, I added a type param.