### PR TITLE
Fix struct annotation for HashXHistoryValue. TxNums now little-endian.

### DIFF
--- a/db/prefixes/prefixes.go
+++ b/db/prefixes/prefixes.go
@@ -513,7 +513,7 @@ type HashXHistoryKey struct {
 }
 
 type HashXHistoryValue struct {
-	TxNums []uint32 `struct-while:"!_eof" json:"tx_nums"`
+	TxNums []uint32 `struct:"lsb" struct-while:"!_eof" json:"tx_nums"`
 }
 
 func (k *HashXHistoryKey) String() string {


### PR DESCRIPTION
Oops. Last merge broke unit tests. (https://github.com/lbryio/herald.go/commit/78b9a625eb8c8a1b1af245a5848e295d1c46da7b)