### PR TITLE
JSON RPC compatibility workarounds to support lbry-sdk

### DIFF
--- a/server/jsonrpc_server.go
+++ b/server/jsonrpc_server.go
@@ -73,17 +73,16 @@ type ServerVersionService struct {
 	Args *Args
 }
 
-type ServerVersionReq struct{}
+type ServerVersionReq [2]string // [client_name, client_version]
 
-type ServerVersionRes string
+type ServerVersionRes [2]string // [version, protocol_version]
 
-// Banner is the json rpc endpoint for 'server.version'.
-// FIXME: This should return a struct with the version and the protocol version.
-// <<-- that comment was written by github, scary shit because it's true
+// Version is the json rpc endpoint for 'server.version'.
 func (t *ServerService) Version(req *ServerVersionReq, res **ServerVersionRes) error {
-	log.Println("Version")
-
-	*res = (*ServerVersionRes)(&t.Args.ServerVersion)
-
+	// FIXME: We may need to do the computation of a negotiated version here.
+	// Also return an error if client is not supported?
+	result := [2]string{t.Args.ServerVersion, t.Args.ServerVersion}
+	*res = (*ServerVersionRes)(&result)
+	log.Printf("Version(%v) -> %v", *req, **res)
 	return nil
 }

--- a/server/session.go
+++ b/server/session.go
@@ -426,8 +426,11 @@ type serverResponse struct {
 }
 
 // jsonPatchingCodec is able to intercept the JSON requests/responses
-// and tweak them. Currently it appears we need to add a
-// "jsonrpc": "1.0" or "jsonrpc": "2.0" to make the client happy.
+// and tweak them. Currently, it appears we need to make several changes:
+// 1) add "jsonrpc": "2.0" (or "jsonrpc": "1.0") in response
+// 2) add newline to frame response
+// 3) add "params": [] when "params" is missing
+// 4) replace params ["arg1", "arg2", ...] with [["arg1", "arg2", ...]]
 type jsonPatchingCodec struct {
 	conn      net.Conn
 	inBuffer  *bytes.Buffer

--- a/signal.go
+++ b/signal.go
@@ -49,10 +49,6 @@ func interruptListener() <-chan struct{} {
 			case sig := <-interruptChannel:
 				log.Infof("Received signal (%s).  Already "+
 					"shutting down...", sig)
-
-			case <-shutdownRequestChannel:
-				log.Info("Shutdown requested.  Already " +
-					"shutting down...")
 			}
 		}
 	}()


### PR DESCRIPTION

Note `--json-rpc-port=50002`. Lots of tests use that port number when launching herald apparently:
```go build -o herald . && ./herald serve --disable-es --json-rpc-port=50002 --json-rpc-http-port=0 --db-path /Users/swdev1/hub/scribe_db.1030239/lbry-rocksdb --session-timeout=15 --max-sessions=5```

With herald running, launch a test. The python herald will be blocked from reusing 50002 because go herald is already running:
```python -m unittest -vv -k test_repost tests/integration/claims/test_claim_commands.py```

```
INFO[2022-10-27T16:03:05-04:00] Accepted: [::1]:53046                        
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive header              
INFO[2022-10-27T16:03:05-04:00] raw request: {"jsonrpc": "2.0", "method": "server.version", "id": 0, "params": ["0.110.0", "0.110.0"]} 
INFO[2022-10-27T16:03:05-04:00] patched request: {"jsonrpc":"2.0","method":"server.version","params":[["0.110.0","0.110.0"]],"id":0} 
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive header: rpc.Request{ServiceMethod:"server.version", Seq:0x1, next:(*rpc.Request)(nil)} 
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive body                
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive body: &server.ServerVersionReq{"0.110.0", "0.110.0"} 
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive header              
INFO[2022-10-27T16:03:05-04:00] Version([0.110.0 0.110.0]) -> [0.107.0 0.107.0] 
INFO[2022-10-27T16:03:05-04:00] respond to [::1]:53046                       
INFO[2022-10-27T16:03:05-04:00] raw response: {"id":0,"result":["0.107.0","0.107.0"],"error":null} 
INFO[2022-10-27T16:03:05-04:00] patched response: {"jsonrpc":"2.0","id":0,"result":["0.107.0","0.107.0"]} 
INFO[2022-10-27T16:03:05-04:00] raw request: {"jsonrpc": "2.0", "method": "server.features", "id": 1} 
INFO[2022-10-27T16:03:05-04:00] patched request: {"jsonrpc":"2.0","method":"server.features","params":[],"id":1} 
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive header: rpc.Request{ServiceMethod:"server.features", Seq:0x2, next:(*rpc.Request)(nil)} 
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive body                
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive body: &server.ServerFeaturesReq{} 
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive header              
INFO[2022-10-27T16:03:05-04:00] Features                                     
INFO[2022-10-27T16:03:05-04:00] respond to [::1]:53046                       
INFO[2022-10-27T16:03:05-04:00] raw response: {"id":1,"result":{"hosts":{},"pruning":"","server_version":"0.107.0","protocol_min":"0.54.0","protocol_max":"0.199.0","genesis_hash":"9c89283ba0f3227f6c03b70216b9f665f0118d5e0fa729cedf4fb34d6a34f463","description":"Herald","payment_address":"","donation_address":"","daily_fee":"1.0","hash_function":"sha256","trending_algorithm":"fast_ar"},"error":null} 
INFO[2022-10-27T16:03:05-04:00] patched response: {"jsonrpc":"2.0","id":1,"result":{"daily_fee":"1.0","description":"Herald","donation_address":"","genesis_hash":"9c89283ba0f3227f6c03b70216b9f665f0118d5e0fa729cedf4fb34d6a34f463","hash_function":"sha256","hosts":{},"payment_address":"","protocol_max":"0.199.0","protocol_min":"0.54.0","pruning":"","server_version":"0.107.0","trending_algorithm":"fast_ar"}} 
INFO[2022-10-27T16:03:05-04:00] raw request: {"jsonrpc": "2.0", "method": "server.peers.subscribe", "id": 2} 
INFO[2022-10-27T16:03:05-04:00] patched request: {"jsonrpc":"2.0","method":"server.peers.subscribe","params":[],"id":2} 
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive header: rpc.Request{ServiceMethod:"server.peers.subscribe", Seq:0x3, next:(*rpc.Request)(nil)} 
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive body                
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive body: <nil>         
INFO[2022-10-27T16:03:05-04:00] respond to [::1]:53046                       
INFO[2022-10-27T16:03:05-04:00] raw response: {"id":2,"result":null,"error":"rpc: can't find service server.peers.Subscribe"} 
INFO[2022-10-27T16:03:05-04:00] patched response: {"jsonrpc":"2.0","id":2,"error":"rpc: can't find service server.peers.Subscribe"} 
INFO[2022-10-27T16:03:05-04:00] from [::1]:53046 receive header              
WARN[2022-10-27T16:03:25-04:00] error: read tcp [::1]:50002->[::1]:53046: use of closed network connection 
INFO[2022-10-27T16:03:25-04:00] session [::1]:53046 goroutine exit           
INFO[2022-10-27T16:03:25-04:00] session [::1]:53046 timed out                
```
